### PR TITLE
Refine role handling and validation

### DIFF
--- a/app/Enums/UserRole.php
+++ b/app/Enums/UserRole.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Enums;
+
+enum UserRole: string
+{
+    case SuperAdmin = 'superadmin';
+    case Admin = 'admin';
+    case User = 'user';
+
+    /**
+     * Return the human readable label for the role.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::SuperAdmin => __('Super Admin'),
+            self::Admin => __('Admin'),
+            self::User => __('User'),
+        };
+    }
+
+    /**
+     * Get the list of role values.
+     *
+     * @return array<int, string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn (self $role) => $role->value, self::cases());
+    }
+}

--- a/app/Http/Controllers/Api/Auth/RegisterController.php
+++ b/app/Http/Controllers/Api/Auth/RegisterController.php
@@ -20,7 +20,7 @@ class RegisterController extends Controller
     {
         $validator = Validator::make($request->all(), [
             'name' => 'required|string|max:255',
-            'username' => 'required|string|alpha_num|lowercase|min:3|max:255|unique:users',
+            'username' => 'required|string|regex:/^[a-z0-9_]+$/|lowercase|min:3|max:255|unique:users',
             'email' => 'required|string|email|max:255|indisposable|unique:users',
             'password' => 'required|string|min:8|confirmed',
         ]);

--- a/app/Http/Requests/Api/StoreUserRequest.php
+++ b/app/Http/Requests/Api/StoreUserRequest.php
@@ -2,45 +2,17 @@
 
 namespace App\Http\Requests\Api;
 
-use App\Models\User;
+use App\Http\Requests\User\StoreUserRequest as BaseStoreUserRequest;
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Response;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\ValidationException;
 
-class StoreUserRequest extends FormRequest
+class StoreUserRequest extends BaseStoreUserRequest
 {
-    protected $roles;
-    public function prepareForValidation()
-    {
-        // Inisialisasi nilai enum dari model
-        $this->roles = implode(',', User::getRoleOptions());
-    }
-
     /**
-     * Determine if the user is authorized to make this request.
+     * @throws ValidationException
      */
-    public function authorize(): bool
-    {
-        return true;
-    }
-
-    /**
-     * Get the validation rules that apply to the request.
-     *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
-     */
-    public function rules(): array
-    {
-        return [
-            'name' => 'required|string|max:255',
-            'username' => 'required|string|min:4|max:25|alpha_num|lowercase|unique:users,username',
-            'role' => 'required|in:' . $this->roles,
-            'email' => 'required|string|email|indisposable|max:255|unique:users,email',
-            'password' => 'required|string|min:6',
-        ];
-    }
-
-    public function failedValidation(\Illuminate\Contracts\Validation\Validator $validator)
+    protected function failedValidation(Validator $validator): void
     {
         $response = response()->json([
             'success' => false,

--- a/app/Http/Requests/Auth/RegisterRequest.php
+++ b/app/Http/Requests/Auth/RegisterRequest.php
@@ -29,7 +29,7 @@ class RegisterRequest extends FormRequest
     {
         $this->ensureIsNotRateLimited();
         return [
-            'username' => ['required', 'string', 'min:3', 'max:25', 'unique:users,username', 'alpha_num', 'lowercase'],
+            'username' => ['required', 'string', 'min:3', 'max:25', 'unique:users,username', 'regex:/^[a-z0-9_]+$/', 'lowercase'],
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'indisposable', 'max:255', 'unique:' . User::class],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],

--- a/app/Http/Requests/User/StoreUserRequest.php
+++ b/app/Http/Requests/User/StoreUserRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use App\Enums\UserRole;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+
+class StoreUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'username' => ['required', 'string', 'min:4', 'max:25', 'alpha_num', 'lowercase', 'unique:users,username'],
+            'role' => ['required', new Enum(UserRole::class)],
+            'email' => ['required', 'string', 'email:filter', 'indisposable', 'max:255', 'unique:users,email'],
+            'email_verified_at' => ['nullable', 'boolean'],
+            'password' => ['required', 'string', 'min:6'],
+        ];
+    }
+}

--- a/app/Http/Requests/User/StoreUserRequest.php
+++ b/app/Http/Requests/User/StoreUserRequest.php
@@ -20,7 +20,7 @@ class StoreUserRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'username' => ['required', 'string', 'min:4', 'max:25', 'alpha_num', 'lowercase', 'unique:users,username'],
+            'username' => ['required', 'string', 'min:4', 'max:25', 'regex:/^[a-z0-9_]+$/', 'lowercase', 'unique:users,username'],
             'role' => ['required', new Enum(UserRole::class)],
             'email' => ['required', 'string', 'email:filter', 'indisposable', 'max:255', 'unique:users,email'],
             'email_verified_at' => ['nullable', 'boolean'],

--- a/app/Http/Requests/User/UpdateUserRequest.php
+++ b/app/Http/Requests/User/UpdateUserRequest.php
@@ -24,7 +24,7 @@ class UpdateUserRequest extends FormRequest
 
         return [
             'name' => ['required', 'string', 'max:255'],
-            'username' => ['required', 'string', 'min:4', 'max:25', 'alpha_num', 'lowercase', Rule::unique('users', 'username')->ignore($userId)],
+            'username' => ['required', 'string', 'min:4', 'max:25', 'regex:/^[a-z0-9_]+$/', 'lowercase', Rule::unique('users', 'username')->ignore($userId)],
             'role' => ['required', new Enum(UserRole::class)],
             'email' => ['required', 'string', 'email:filter', 'indisposable', 'max:255', Rule::unique('users', 'email')->ignore($userId)],
             'email_verified_at' => ['nullable', 'boolean'],

--- a/app/Http/Requests/User/UpdateUserRequest.php
+++ b/app/Http/Requests/User/UpdateUserRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Enum;
+
+class UpdateUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $userId = $this->resolveUserId();
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'username' => ['required', 'string', 'min:4', 'max:25', 'alpha_num', 'lowercase', Rule::unique('users', 'username')->ignore($userId)],
+            'role' => ['required', new Enum(UserRole::class)],
+            'email' => ['required', 'string', 'email:filter', 'indisposable', 'max:255', Rule::unique('users', 'email')->ignore($userId)],
+            'email_verified_at' => ['nullable', 'boolean'],
+            'password' => ['nullable', 'string', 'min:6'],
+        ];
+    }
+
+    protected function resolveUserId(): string|int|null
+    {
+        $user = $this->route('user');
+
+        return $user instanceof User ? $user->getKey() : $user;
+    }
+}

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use App\Enums\UserRole;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -14,14 +15,21 @@ class UserResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        $role = $this->resource->role;
+        $roleValue = $role instanceof UserRole ? $role->value : $role;
+
         return [
             'id' => $this->id,
             'name' => $this->name,
             'username' => $this->username,
             'email' => $this->email,
-            'role' => $this->role,
+            'role' => $roleValue,
             'email_verified_at' => $this->email_verified_at,
-            'profile_photo_path' => config('app.url') . $this->profile_photo_path,
+            'profile_photo_path' => $this->profile_photo_path,
+            'profile_photo_url' => asset($this->profile_photo_path),
+            'provider_name' => $this->provider_name,
+            'created_at' => $this->created_at,
+            'created_at_formatted' => $this->created_at?->format('d M Y'),
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,14 +2,14 @@
 
 namespace App\Models;
 
-use Laravel\Sanctum\HasApiTokens;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Notifications\Notifiable;
-use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Enums\UserRole;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
@@ -32,7 +32,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'provider_id',
         'provider_name',
         'provider_token',
-        'provider_refresh_token'
+        'provider_refresh_token',
     ];
 
     /**
@@ -44,7 +44,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'password',
         'remember_token',
         'provider_token',
-        'provider_refresh_token'
+        'provider_refresh_token',
     ];
 
     /**
@@ -57,28 +57,7 @@ class User extends Authenticatable implements MustVerifyEmail
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'role' => UserRole::class,
         ];
-    }
-
-    public static function getRoleOptions()
-    {
-        // Check the type of database being used
-        $driver = DB::getDriverName();
-
-        if ($driver === 'mysql') {
-            // Retrieve column description from the users table
-            $column = DB::select("SHOW COLUMNS FROM users WHERE Field = 'role'");
-            // Extract data type from query result
-            $type = $column[0]->Type;
-            // Extract enum values using regex
-            preg_match('/enum\((.*)\)/', $type, $matches);
-            // Return enum values as an array
-            return str_getcsv($matches[1], ',', "'");
-        } elseif ($driver === 'sqlite') {
-            // If using SQLite, ENUM is not supported, an alternative solution must be created.
-            return ['superadmin', 'user']; // Adjust according to expected values
-        }
-
-        return []; // Return empty if the driver is not recognized
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\UserRole;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -28,7 +29,7 @@ class UserFactory extends Factory
             'name' => fake()->name(),
             'username' => fake()->unique()->userName(),
             'email' => fake()->unique()->safeEmail(),
-            'role' => 'user',
+            'role' => UserRole::User->value,
             'profile_photo_path' => '/assets/img/profile/user.png',
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),

--- a/database/seeders/Users.php
+++ b/database/seeders/Users.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Enums\UserRole;
 use App\Models\User;
 use Illuminate\Support\Str;
 use Illuminate\Database\Seeder;
@@ -21,7 +22,7 @@ class Users extends Seeder
                 'username' => 'superadmin',
                 'email' => 'superadmin@mail.com',
                 'password' => Hash::make('superadmin'),
-                'role' => 'superadmin',
+                'role' => UserRole::SuperAdmin->value,
                 'profile_photo_path' => '/assets/img/profile/admin.png',
                 'created_at' => now(),
                 'email_verified_at' => now(),
@@ -33,7 +34,7 @@ class Users extends Seeder
                 'username' => 'admin',
                 'email' => 'admin@mail.com',
                 'password' => Hash::make('admin'),
-                'role' => 'admin',
+                'role' => UserRole::Admin->value,
                 'profile_photo_path' => '/assets/img/profile/admin.png',
                 'email_verified_at' => now(),
                 'created_at' => now(),
@@ -45,7 +46,7 @@ class Users extends Seeder
                 'username' => 'user',
                 'email' => 'user@mail.com',
                 'password' => Hash::make('user'),
-                'role' => 'user',
+                'role' => UserRole::User->value,
                 'profile_photo_path' => '/assets/img/profile/user.png',
                 'email_verified_at' => now(),
                 'created_at' => now(),

--- a/resources/views/components/dashboard/sidebar-nav.blade.php
+++ b/resources/views/components/dashboard/sidebar-nav.blade.php
@@ -1,3 +1,15 @@
+@php
+    use App\Enums\UserRole;
+    use Illuminate\Support\Facades\Auth;
+
+    $currentUser = Auth::user();
+    $isSuperAdmin = $currentUser && (
+        $currentUser->role instanceof UserRole
+            ? $currentUser->role === UserRole::SuperAdmin
+            : $currentUser->role === UserRole::SuperAdmin->value
+    );
+@endphp
+
 <nav class="hs-accordion-group flex w-full flex-col flex-wrap p-3" data-hs-accordion-always-open>
     <ul class="flex flex-col space-y-1">
         <x-dashboard.nav-item href="/" icon="ri-home-4-line" text="{{ __('Home') }}" />
@@ -18,12 +30,12 @@
         <div class="text-base-content-muted border-foreground/20 border-b px-1 pt-3 text-sm font-bold">
             <p>{{ __('Manage') }}</p>
         </div>
-        @if (Auth::user()->role == 'superadmin')
+        @if ($isSuperAdmin)
             <x-dashboard.nav-item href="admin.users.index" icon="ri-user-line" text="{{ __('Users') }}" />
             <x-dashboard.nav-item href="docs" icon="ri-file-list-3-line" text="{{ __('Route Docs') }}" target="_blank" />
         @endif
 
-        @if (Auth::user()->role == 'superadmin')
+        @if ($isSuperAdmin)
             <div class="text-base-content-muted border-foreground/30 border-b px-1 pt-3 text-sm font-bold">
                 <p>{{ __('Settings') }}</p>
             </div>

--- a/resources/views/pages/dashboard/users/index.blade.php
+++ b/resources/views/pages/dashboard/users/index.blade.php
@@ -86,7 +86,7 @@
                                     <x-input-label for="role" :value="__('Role')" />
                                     <x-select-input id="role" name="role">
                                         @foreach ($roles as $role)
-                                            <option value="{{ $role }}">{{ ucfirst($role) }}</option>
+                                            <option value="{{ $role->value }}">{{ $role->label() }}</option>
                                         @endforeach
                                     </x-select-input>
                                 </div>

--- a/resources/views/pages/dashboard/users/index.blade.php
+++ b/resources/views/pages/dashboard/users/index.blade.php
@@ -301,7 +301,7 @@
                         },
                         success: function(response) {
                             closeModal('#user-modal');
-                            $('#myTable').DataTable().ajax.reload();
+                            $('#myTable').DataTable().ajax.reload(null, false);
                             MyZkToast.success(response.message);
                         },
                         error: function(error) {
@@ -353,7 +353,7 @@
                         type: "DELETE",
                         url: `{{ route('admin.users.destroy', ':userId') }}`.replace(':userId', userId),
                         success: function(response) {
-                            $('#myTable').DataTable().ajax.reload();
+                            $('#myTable').DataTable().ajax.reload(null, false);
                             MyZkToast.success(response.message);
                         },
                         error: function(error) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,12 @@ use App\Http\Controllers\Socialite\ProviderRedirectController;
 Route::get('/auth/{provider}/redirect', ProviderRedirectController::class)->name('auth.redirect');
 Route::get('/auth/{provider}/callback', ProviderCallbackController::class)->name('auth.callback');
 
+if (app()->environment('testing')) {
+    Route::middleware(['auth', 'role:superadmin'])
+        ->get('/test-superadmin', fn () => response()->noContent())
+        ->name('test.superadmin');
+}
+
 // Dashboard Routes
 Route::prefix('dashboard')->name('admin.')->group(function () {
     // Super Admin Only Routes

--- a/tests/Feature/RoleCheckMiddlewareTest.php
+++ b/tests/Feature/RoleCheckMiddlewareTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class RoleCheckMiddlewareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! Route::has('test.superadmin')) {
+            Route::middleware(['web', 'auth', 'role:superadmin'])
+                ->get('/test-superadmin', fn () => response()->noContent())
+                ->name('test.superadmin');
+        }
+    }
+
+    public function test_superadmin_can_access_protected_route(): void
+    {
+        $user = User::factory()->create([
+            'role' => UserRole::SuperAdmin->value,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('test.superadmin'));
+
+        $response->assertNoContent();
+    }
+
+    public function test_non_superadmin_is_forbidden(): void
+    {
+        $user = User::factory()->create([
+            'role' => UserRole::User->value,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('test.superadmin'));
+
+        $response->assertForbidden();
+    }
+}

--- a/tests/Unit/UserRoleTest.php
+++ b/tests/Unit/UserRoleTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Enums\UserRole;
+use Tests\TestCase;
+
+class UserRoleTest extends TestCase
+{
+    public function test_values_returns_all_roles(): void
+    {
+        $this->assertSame([
+            'superadmin',
+            'admin',
+            'user',
+        ], UserRole::values());
+    }
+
+    public function test_label_returns_translated_string(): void
+    {
+        $this->assertSame(__('Super Admin'), UserRole::SuperAdmin->label());
+        $this->assertSame(__('Admin'), UserRole::Admin->label());
+        $this->assertSame(__('User'), UserRole::User->label());
+    }
+}


### PR DESCRIPTION
## Summary
- centralize user role handling with a new enum and apply it across models, middleware, views, factories, and seeders
- refactor user store/update workflows to use shared form requests, normalized email verification logic, and richer API/web resources
- add regression coverage for role validation and middleware authorization behaviour

## Testing
- `php artisan test` *(fails: composer install could not download dependencies because GitHub access returned HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_b_68e5a3a698e48324ae3cea7bc3cbfab3