### PR TITLE
Add queued mail sending route and profile photo processing job

### DIFF
--- a/app/Http/Controllers/MailController.php
+++ b/app/Http/Controllers/MailController.php
@@ -12,14 +12,17 @@ class MailController extends Controller
     {
         $user = User::where('username', $username)->firstOrFail();
 
-        SendUserMail::dispatch($user->email, $user->name);
+        for ($i = 0; $i < 5; $i++) {
+            SendUserMail::dispatch($user->email, $user->name);
+        }
 
         return response()->json([
-            'message' => 'Email is being sent via queue.',
+            'message' => '5 queued emails are being sent.',
             'user' => [
                 'username' => $user->username,
                 'email' => $user->email,
             ],
+            'queued_jobs' => 5,
         ], 202);
     }
 }

--- a/app/Http/Controllers/MailController.php
+++ b/app/Http/Controllers/MailController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Jobs\SendUserMail;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+
+class MailController extends Controller
+{
+    public function sendToUser(string $username): JsonResponse
+    {
+        $user = User::where('username', $username)->firstOrFail();
+
+        SendUserMail::dispatch($user->email, $user->name);
+
+        return response()->json([
+            'message' => 'Email is being sent via queue.',
+            'user' => [
+                'username' => $user->username,
+                'email' => $user->email,
+            ],
+        ], 202);
+    }
+}

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\ProfileUpdateRequest;
+use App\Jobs\ProcessProfilePhoto;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -85,6 +86,9 @@ class ProfileController extends Controller
         // Menyimpan file ke storage publik dengan nama baru
         $file->storeAs('profile_photos', $newFileName, 'public');
         $path = '/storage/profile_photos/' . $newFileName;
+        // Menyimulasikan proses manipulasi foto melalui queue
+        ProcessProfilePhoto::dispatch($user->id, $path);
+
         // Memperbarui foto profil pengguna
         $user->update([
             'profile_photo_path' => $path, // Menyimpan path file di database

--- a/app/Jobs/ProcessProfilePhoto.php
+++ b/app/Jobs/ProcessProfilePhoto.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessProfilePhoto implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public string $userId, public string $photoPath)
+    {
+    }
+
+    public function handle(): void
+    {
+        sleep(5);
+    }
+
+    public function tags(): array
+    {
+        return ['profile-photo', "user:{$this->userId}"];
+    }
+}

--- a/app/Jobs/ProcessProfilePhoto.php
+++ b/app/Jobs/ProcessProfilePhoto.php
@@ -12,6 +12,11 @@ class ProcessProfilePhoto implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /**
+     * The queue connection name where the job should be pushed.
+     */
+    public string $queue = 'images';
+
     public function __construct(public string $userId, public string $photoPath)
     {
     }
@@ -23,6 +28,6 @@ class ProcessProfilePhoto implements ShouldQueue
 
     public function tags(): array
     {
-        return ['profile-photo', "user:{$this->userId}"];
+        return ['images', 'profile-photo', "user:{$this->userId}"];
     }
 }

--- a/app/Jobs/SendUserMail.php
+++ b/app/Jobs/SendUserMail.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Mail;
+
+class SendUserMail implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public string $email, public string $name)
+    {
+        $this->onQueue('emails');
+    }
+
+    public function handle(): void
+    {
+        Mail::raw(
+            "Hello {$this->name}, this is a queued email notification.",
+            function ($message) {
+                $message->to($this->email)
+                    ->subject('Queued Email Notification');
+            }
+        );
+    }
+
+    public function tags(): array
+    {
+        return ['emails', "user:{$this->email}"];
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\MailController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Socialite\ProviderCallbackController;
 use App\Http\Controllers\Socialite\ProviderRedirectController;
@@ -69,6 +70,9 @@ Route::get('/', [HomeController::class, 'index'])->name('home');
 Route::get('/docs', function () {
     return view('pages.docs');
 })->name('docs');
+
+Route::get('/send-mail-to/{username}', [MailController::class, 'sendToUser'])
+    ->name('send-mail-to');
 
 
 // Authentication Routes


### PR DESCRIPTION
## Summary
- add a MailController endpoint that dispatches queued emails by username
- introduce queue jobs for sending user email and simulating profile photo processing
- trigger the simulated photo manipulation job whenever a profile picture is uploaded

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ef998e1fa08324a91988c45d67d7be